### PR TITLE
[냥인] 쿠폰 수정 기능 동시성 문제 해결

### DIFF
--- a/docker/init/schema.sql
+++ b/docker/init/schema.sql
@@ -1,4 +1,4 @@
-create database if not exists coupon
+create database if not exists coupon;
 use coupon;
 
 create table if not exists coupon

--- a/docker/init/schema.sql
+++ b/docker/init/schema.sql
@@ -9,7 +9,8 @@ create table if not exists coupon
     minimum_order_price DECIMAL(10, 2) NOT NULL,
     coupon_category     VARCHAR(50)    NOT NULL,
     issue_started_at    DATETIME      NOT NULL,
-    issue_ended_at      DATETIME      NOT NULL
+    issue_ended_at      DATETIME      NOT NULL,
+    version             INT           NOT NULL
 ) engine = InnoDB;
 
 create table if not exists member_coupon

--- a/src/main/java/coupon/GlobalExceptionHandler.java
+++ b/src/main/java/coupon/GlobalExceptionHandler.java
@@ -1,0 +1,23 @@
+package coupon;
+
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ProblemDetail;
+import org.springframework.http.ResponseEntity;
+import org.springframework.orm.ObjectOptimisticLockingFailureException;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+import org.springframework.web.servlet.mvc.method.annotation.ResponseEntityExceptionHandler;
+
+@RestControllerAdvice
+public class GlobalExceptionHandler extends ResponseEntityExceptionHandler {
+
+    @ExceptionHandler(ObjectOptimisticLockingFailureException.class)
+    public ResponseEntity<ProblemDetail> handleOptimisticLockFailure(ObjectOptimisticLockingFailureException e) {
+        ProblemDetail problemDetail = ProblemDetail.forStatusAndDetail(
+                HttpStatus.CONFLICT,
+                "데이터가 다른 사용자에 의해 수정되었습니다. 다시 시도해주세요."
+        );
+        return ResponseEntity.status(HttpStatus.CONFLICT)
+                .body(problemDetail);
+    }
+}

--- a/src/main/java/coupon/coupon/domain/Coupon.java
+++ b/src/main/java/coupon/coupon/domain/Coupon.java
@@ -147,6 +147,11 @@ public class Coupon implements Serializable {
         }
     }
 
+    public void updateDiscountAmount(BigDecimal newDiscountAmount) {
+        validateDiscountAmount(newDiscountAmount);
+        this.discountAmount = newDiscountAmount;
+    }
+
     @Override
     public boolean equals(Object o) {
         if (this == o) {

--- a/src/main/java/coupon/coupon/domain/Coupon.java
+++ b/src/main/java/coupon/coupon/domain/Coupon.java
@@ -152,6 +152,11 @@ public class Coupon implements Serializable {
         this.discountAmount = newDiscountAmount;
     }
 
+    public void updateMinimumOrderPrice(BigDecimal newMinimumOrderPrice) {
+        validateMinimumOrderPrice(newMinimumOrderPrice);
+        this.minimumOrderPrice = newMinimumOrderPrice;
+    }
+
     @Override
     public boolean equals(Object o) {
         if (this == o) {

--- a/src/main/java/coupon/coupon/domain/Coupon.java
+++ b/src/main/java/coupon/coupon/domain/Coupon.java
@@ -19,7 +19,9 @@ import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import org.hibernate.annotations.DynamicUpdate;
 
+@DynamicUpdate
 @Table(name = "coupon")
 @Entity
 @NoArgsConstructor(access = AccessLevel.PROTECTED)

--- a/src/main/java/coupon/coupon/domain/Coupon.java
+++ b/src/main/java/coupon/coupon/domain/Coupon.java
@@ -153,11 +153,13 @@ public class Coupon implements Serializable {
 
     public void updateDiscountAmount(BigDecimal newDiscountAmount) {
         validateDiscountAmount(newDiscountAmount);
+        validateDiscountRate(newDiscountAmount, this.minimumOrderPrice);
         this.discountAmount = newDiscountAmount;
     }
 
     public void updateMinimumOrderPrice(BigDecimal newMinimumOrderPrice) {
         validateMinimumOrderPrice(newMinimumOrderPrice);
+        validateDiscountRate(this.discountAmount, newMinimumOrderPrice);
         this.minimumOrderPrice = newMinimumOrderPrice;
     }
 

--- a/src/main/java/coupon/coupon/domain/Coupon.java
+++ b/src/main/java/coupon/coupon/domain/Coupon.java
@@ -8,6 +8,7 @@ import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
 import jakarta.persistence.Table;
+import jakarta.persistence.Version;
 import java.io.Serializable;
 import java.math.BigDecimal;
 import java.math.RoundingMode;
@@ -66,6 +67,9 @@ public class Coupon implements Serializable {
 
     @Column(name = "issue_ended_at", nullable = false)
     private LocalDateTime issueEndedAt;
+
+    @Version
+    private Integer version;
 
     public Coupon(String name, BigDecimal discountAmount, BigDecimal minimumOrderPrice, CouponCategory couponCategory,
             LocalDateTime issueStartedAt, LocalDateTime issueEndedAt) {

--- a/src/main/java/coupon/coupon/service/CouponService.java
+++ b/src/main/java/coupon/coupon/service/CouponService.java
@@ -8,6 +8,7 @@ import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.cache.annotation.CachePut;
 import org.springframework.cache.annotation.Cacheable;
+import org.springframework.orm.ObjectOptimisticLockingFailureException;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -48,6 +49,11 @@ public class CouponService {
                 .orElseThrow(() -> new IllegalArgumentException("존재하지 않는 쿠폰입니다. couponId: %d ".formatted(couponId)));
 
         coupon.updateDiscountAmount(newDiscountAmount);
+        try {
+            couponRepository.flush();
+        } catch (ObjectOptimisticLockingFailureException e) {
+            throw new RuntimeException("할인 금액을 업데이트하는 도중에 다른 사용자가 데이터를 변경하였습니다. couponId: %d".formatted(couponId));
+        }
     }
 
     @Transactional
@@ -55,5 +61,10 @@ public class CouponService {
         Coupon coupon = couponRepository.findById(couponId)
                 .orElseThrow(() -> new IllegalArgumentException("존재하지 않는 쿠폰입니다. couponId: %d ".formatted(couponId)));
         coupon.updateMinimumOrderPrice(newMinimumOrderPrice);
+        try {
+            couponRepository.flush();
+        } catch (ObjectOptimisticLockingFailureException e) {
+            throw new RuntimeException("최소 주문 금액을 업데이트하는 도중에 다른 사용자가 데이터를 변경하였습니다. couponId: %d".formatted(couponId));
+        }
     }
 }

--- a/src/main/java/coupon/coupon/service/CouponService.java
+++ b/src/main/java/coupon/coupon/service/CouponService.java
@@ -2,18 +2,22 @@ package coupon.coupon.service;
 
 import coupon.coupon.domain.Coupon;
 import coupon.coupon.domain.repository.CouponRepository;
+import coupon.util.NewTransactionExecutor;
 import java.math.BigDecimal;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.cache.annotation.CachePut;
 import org.springframework.cache.annotation.Cacheable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+@Slf4j
 @Service
 @RequiredArgsConstructor
 public class CouponService {
 
     private final CouponRepository couponRepository;
+    private final NewTransactionExecutor newTransactionExecutor;
 
     @Transactional
     @CachePut(key = "#result.id", value = "coupon")
@@ -26,6 +30,16 @@ public class CouponService {
     public Coupon getCoupon(long couponId) {
         return couponRepository.findById(couponId)
                 .orElseThrow(() -> new IllegalArgumentException("존재하지 않는 쿠폰입니다. couponId: %d ".formatted(couponId)));
+    }
+
+    @Transactional(readOnly = true)
+    public Coupon getCouponForce(long couponId) {
+        return couponRepository.findById(couponId)
+                .orElseGet(() -> {
+                    log.info("Switching to write DB");
+                    return newTransactionExecutor.execute(() -> getCouponForce(couponId));
+                }
+        );
     }
 
     @Transactional

--- a/src/main/java/coupon/coupon/service/CouponService.java
+++ b/src/main/java/coupon/coupon/service/CouponService.java
@@ -45,8 +45,7 @@ public class CouponService {
 
     @Transactional
     public void updateCouponField(Long couponId, Consumer<Coupon> updateField) {
-        Coupon coupon = couponRepository.findById(couponId)
-                .orElseThrow(() -> new IllegalArgumentException("존재하지 않는 쿠폰입니다. couponId: %d ".formatted(couponId)));
+        Coupon coupon = getCouponForce(couponId);
         updateField.accept(coupon);
     }
 

--- a/src/main/java/coupon/coupon/service/CouponService.java
+++ b/src/main/java/coupon/coupon/service/CouponService.java
@@ -4,11 +4,11 @@ import coupon.coupon.domain.Coupon;
 import coupon.coupon.domain.repository.CouponRepository;
 import coupon.util.NewTransactionExecutor;
 import java.math.BigDecimal;
+import java.util.function.Consumer;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.cache.annotation.CachePut;
 import org.springframework.cache.annotation.Cacheable;
-import org.springframework.orm.ObjectOptimisticLockingFailureException;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -37,34 +37,26 @@ public class CouponService {
     public Coupon getCouponForce(long couponId) {
         return couponRepository.findById(couponId)
                 .orElseGet(() -> {
-                    log.info("Switching to write DB");
-                    return newTransactionExecutor.execute(() -> getCouponForce(couponId));
-                }
-        );
+                            log.info("Switching to write DB");
+                            return newTransactionExecutor.execute(() -> getCouponForce(couponId));
+                        }
+                );
+    }
+
+    @Transactional
+    public void updateCouponField(Long couponId, Consumer<Coupon> updateField) {
+        Coupon coupon = couponRepository.findById(couponId)
+                .orElseThrow(() -> new IllegalArgumentException("존재하지 않는 쿠폰입니다. couponId: %d ".formatted(couponId)));
+        updateField.accept(coupon);
     }
 
     @Transactional
     public void updateDiscountAmount(Long couponId, BigDecimal newDiscountAmount) {
-        Coupon coupon = couponRepository.findById(couponId)
-                .orElseThrow(() -> new IllegalArgumentException("존재하지 않는 쿠폰입니다. couponId: %d ".formatted(couponId)));
-
-        coupon.updateDiscountAmount(newDiscountAmount);
-        try {
-            couponRepository.flush();
-        } catch (ObjectOptimisticLockingFailureException e) {
-            throw new RuntimeException("할인 금액을 업데이트하는 도중에 다른 사용자가 데이터를 변경하였습니다. couponId: %d".formatted(couponId));
-        }
+        updateCouponField(couponId, coupon -> coupon.updateDiscountAmount(newDiscountAmount));
     }
 
     @Transactional
     public void updateMinimumOrderPrice(Long couponId, BigDecimal newMinimumOrderPrice) {
-        Coupon coupon = couponRepository.findById(couponId)
-                .orElseThrow(() -> new IllegalArgumentException("존재하지 않는 쿠폰입니다. couponId: %d ".formatted(couponId)));
-        coupon.updateMinimumOrderPrice(newMinimumOrderPrice);
-        try {
-            couponRepository.flush();
-        } catch (ObjectOptimisticLockingFailureException e) {
-            throw new RuntimeException("최소 주문 금액을 업데이트하는 도중에 다른 사용자가 데이터를 변경하였습니다. couponId: %d".formatted(couponId));
-        }
+        updateCouponField(couponId, coupon -> coupon.updateMinimumOrderPrice(newMinimumOrderPrice));
     }
 }

--- a/src/main/java/coupon/coupon/service/CouponService.java
+++ b/src/main/java/coupon/coupon/service/CouponService.java
@@ -35,4 +35,11 @@ public class CouponService {
 
         coupon.updateDiscountAmount(newDiscountAmount);
     }
+
+    @Transactional
+    public void updateMinimumOrderPrice(Long couponId, BigDecimal newMinimumOrderPrice) {
+        Coupon coupon = couponRepository.findById(couponId)
+                .orElseThrow(() -> new IllegalArgumentException("존재하지 않는 쿠폰입니다. couponId: %d ".formatted(couponId)));
+        coupon.updateMinimumOrderPrice(newMinimumOrderPrice);
+    }
 }

--- a/src/main/java/coupon/coupon/service/CouponService.java
+++ b/src/main/java/coupon/coupon/service/CouponService.java
@@ -2,6 +2,7 @@ package coupon.coupon.service;
 
 import coupon.coupon.domain.Coupon;
 import coupon.coupon.domain.repository.CouponRepository;
+import java.math.BigDecimal;
 import lombok.RequiredArgsConstructor;
 import org.springframework.cache.annotation.CachePut;
 import org.springframework.cache.annotation.Cacheable;
@@ -25,5 +26,13 @@ public class CouponService {
     public Coupon getCoupon(long couponId) {
         return couponRepository.findById(couponId)
                 .orElseThrow(() -> new IllegalArgumentException("존재하지 않는 쿠폰입니다. couponId: %d ".formatted(couponId)));
+    }
+
+    @Transactional
+    public void updateDiscountAmount(Long couponId, BigDecimal newDiscountAmount) {
+        Coupon coupon = couponRepository.findById(couponId)
+                .orElseThrow(() -> new IllegalArgumentException("존재하지 않는 쿠폰입니다. couponId: %d ".formatted(couponId)));
+
+        coupon.updateDiscountAmount(newDiscountAmount);
     }
 }

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -10,7 +10,7 @@ spring:
         default_batch_fetch_size: 128
         id.new_generator_mappings: true
         format_sql: true
-        show_sql: false
+        show_sql: true
         use_sql_comments: true
         hbm2ddl.auto: validate
         check_nullability: true

--- a/src/test/java/coupon/coupon/domain/CouponTest.java
+++ b/src/test/java/coupon/coupon/domain/CouponTest.java
@@ -263,4 +263,24 @@ class CouponTest {
         // then
         assertThat(coupon.getDiscountAmount()).isEqualTo(newDiscountAmount);
     }
+
+    @DisplayName("최소 주문 금액을 변경한다.")
+    @Test
+    void updateMinimumOrderPrice() {
+        // given
+        String name = "냥인의쿠폰";
+        BigDecimal discountAmount = BigDecimal.valueOf(1_000);
+        BigDecimal minimumOrderPrice = BigDecimal.valueOf(5_000);
+        CouponCategory couponCategory = CouponCategory.FOOD;
+        LocalDateTime issueStartedAt = LocalDateTime.of(2024, 10, 16, 0, 0, 0, 0);
+        LocalDateTime issueEndedAt = LocalDateTime.of(2024, 10, 26, 23, 59, 59, 999_999_000);
+        Coupon coupon = new Coupon(name, discountAmount, minimumOrderPrice, couponCategory, issueStartedAt, issueEndedAt);
+        BigDecimal newMinimumOrderPrice = BigDecimal.valueOf(6_000);
+
+        // when
+        coupon.updateMinimumOrderPrice(newMinimumOrderPrice);
+
+        // then
+        assertThat(coupon.getMinimumOrderPrice()).isEqualTo(newMinimumOrderPrice);
+    }
 }

--- a/src/test/java/coupon/coupon/domain/CouponTest.java
+++ b/src/test/java/coupon/coupon/domain/CouponTest.java
@@ -1,5 +1,6 @@
 package coupon.coupon.domain;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import java.math.BigDecimal;
@@ -241,5 +242,25 @@ class CouponTest {
                     new Coupon(name, discountAmount, minimumOrderPrice, couponCategory, issueStartedAt, issueEndedAt))
                     .isInstanceOf(IllegalArgumentException.class);
         }
+    }
+
+    @DisplayName("쿠폰 할인 금액을 변경한다.")
+    @Test
+    void updateDiscountAmount() {
+        // given
+        String name = "냥인의쿠폰";
+        BigDecimal discountAmount = BigDecimal.valueOf(1_000);
+        BigDecimal minimumOrderPrice = BigDecimal.valueOf(5_000);
+        CouponCategory couponCategory = CouponCategory.FOOD;
+        LocalDateTime issueStartedAt = LocalDateTime.of(2024, 10, 16, 0, 0, 0, 0);
+        LocalDateTime issueEndedAt = LocalDateTime.of(2024, 10, 26, 23, 59, 59, 999_999_000);
+        Coupon coupon = new Coupon(name, discountAmount, minimumOrderPrice, couponCategory, issueStartedAt, issueEndedAt);
+        BigDecimal newDiscountAmount = BigDecimal.valueOf(2_000);
+
+        // when
+        coupon.updateDiscountAmount(newDiscountAmount);
+
+        // then
+        assertThat(coupon.getDiscountAmount()).isEqualTo(newDiscountAmount);
     }
 }

--- a/src/test/java/coupon/coupon/domain/CouponTest.java
+++ b/src/test/java/coupon/coupon/domain/CouponTest.java
@@ -250,7 +250,7 @@ class CouponTest {
         // given
         String name = "냥인의쿠폰";
         BigDecimal discountAmount = BigDecimal.valueOf(1_000);
-        BigDecimal minimumOrderPrice = BigDecimal.valueOf(5_000);
+        BigDecimal minimumOrderPrice = BigDecimal.valueOf(10_000);
         CouponCategory couponCategory = CouponCategory.FOOD;
         LocalDateTime issueStartedAt = LocalDateTime.of(2024, 10, 16, 0, 0, 0, 0);
         LocalDateTime issueEndedAt = LocalDateTime.of(2024, 10, 26, 23, 59, 59, 999_999_000);

--- a/src/test/java/coupon/coupon/service/CouponServiceTest.java
+++ b/src/test/java/coupon/coupon/service/CouponServiceTest.java
@@ -5,6 +5,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import coupon.coupon.domain.Coupon;
 import coupon.coupon.domain.CouponCategory;
 import java.math.BigDecimal;
+import java.math.RoundingMode;
 import java.time.LocalDateTime;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Test;
@@ -47,5 +48,42 @@ class CouponServiceTest {
 
         // then
         assertThat(savedCoupon.getId()).isEqualTo(1L);
+    }
+
+    @Test
+    @Sql(scripts = "/reset-database.sql", executionPhase = Sql.ExecutionPhase.AFTER_TEST_METHOD)
+    void 쿠폰_수정_동시성_문제_테스트() throws InterruptedException {
+        // given
+        String name = "냥인의쿠폰";
+        BigDecimal discountAmount = BigDecimal.valueOf(2_500);
+        BigDecimal minimumOrderPrice = BigDecimal.valueOf(30_000);
+        CouponCategory couponCategory = CouponCategory.FOOD;
+        LocalDateTime issueStartedAt = LocalDateTime.of(2024, 10, 16, 0, 0, 0, 0);
+        LocalDateTime issueEndedAt = LocalDateTime.of(2024, 10, 26, 23, 59, 59, 999_999_000);
+        Coupon coupon = new Coupon(
+                name, discountAmount, minimumOrderPrice, couponCategory, issueStartedAt, issueEndedAt
+        );
+        Coupon savedCoupon = couponService.createCoupon(coupon);
+
+        // when
+        // 사용자 1: 쿠폰 할인 금액 변경 기능을 이용하여 할인 금액을 1,000원으로 수정
+        Thread user1 = new Thread(() ->
+                couponService.updateDiscountAmount(savedCoupon.getId(), BigDecimal.valueOf(1_000)));
+        // 사용자 2: 쿠폰 최소 주문 금액 변경 기능을 이용하여 최소 주문 금액을 40,000원으로 수정
+        Thread user2 = new Thread(() ->
+                couponService.updateMinimumOrderPrice(savedCoupon.getId(), BigDecimal.valueOf(40_000)));
+        user1.start();
+        user2.start();
+
+        user1.join();
+        user2.join();
+
+        // then
+        Coupon updatedCoupon = couponService.getCouponForce(savedCoupon.getId());
+        int discountRate = updatedCoupon.getDiscountAmount()
+                .multiply(BigDecimal.valueOf(100))
+                .divide(updatedCoupon.getMinimumOrderPrice(), 0, RoundingMode.DOWN)
+                .intValue();
+        assertThat(discountRate).isBetween(3, 20);
     }
 }

--- a/src/test/java/coupon/coupon/service/CouponServiceTest.java
+++ b/src/test/java/coupon/coupon/service/CouponServiceTest.java
@@ -7,7 +7,9 @@ import coupon.coupon.domain.CouponCategory;
 import java.math.BigDecimal;
 import java.math.RoundingMode;
 import java.time.LocalDateTime;
-import java.util.concurrent.atomic.AtomicReference;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -33,19 +35,8 @@ class CouponServiceTest {
     @Test
     @Sql(scripts = "/reset-database.sql", executionPhase = Sql.ExecutionPhase.AFTER_TEST_METHOD)
     void 복제지연테스트() {
-        // given
-        String name = "냥인의쿠폰";
-        BigDecimal discountAmount = BigDecimal.valueOf(1_000);
-        BigDecimal minimumOrderPrice = BigDecimal.valueOf(5_000);
-        CouponCategory couponCategory = CouponCategory.FOOD;
-        LocalDateTime issueStartedAt = LocalDateTime.of(2024, 10, 16, 0, 0, 0, 0);
-        LocalDateTime issueEndedAt = LocalDateTime.of(2024, 10, 26, 23, 59, 59, 999_999_000);
-        Coupon coupon = new Coupon(
-                name, discountAmount, minimumOrderPrice, couponCategory, issueStartedAt, issueEndedAt
-        );
-
-        // when
-        couponService.createCoupon(coupon);
+        // given & when
+        Coupon coupon = createTestCoupon(BigDecimal.valueOf(1_000), BigDecimal.valueOf(5_000));
         Coupon savedCoupon = couponService.getCoupon(coupon.getId());
 
         // then
@@ -56,34 +47,55 @@ class CouponServiceTest {
     @Sql(scripts = "/reset-database.sql", executionPhase = Sql.ExecutionPhase.AFTER_TEST_METHOD)
     void 쿠폰_수정_동시성_문제_테스트() throws InterruptedException {
         // given
+        Coupon savedCoupon = createTestCoupon(BigDecimal.valueOf(2_500), BigDecimal.valueOf(30_000));
+
+        // when
+        List<Exception> exceptions = executeConcurrentUpdates(
+                () -> couponService.updateDiscountAmount(savedCoupon.getId(), BigDecimal.valueOf(1_000)),
+                () -> couponService.updateMinimumOrderPrice(savedCoupon.getId(), BigDecimal.valueOf(40_000))
+        );
+
+        // then
+        Coupon updatedCoupon = couponService.getCouponForce(savedCoupon.getId());
+        int discountRate = updatedCoupon.getDiscountAmount()
+                .multiply(BigDecimal.valueOf(100))
+                .divide(updatedCoupon.getMinimumOrderPrice(), 0, RoundingMode.DOWN)
+                .intValue();
+        assertThat(discountRate).isBetween(3, 20);
+        assertThat(exceptions)
+                .hasSize(1)
+                .allMatch(e -> e instanceof ObjectOptimisticLockingFailureException);
+    }
+
+    private Coupon createTestCoupon(BigDecimal discountAmount, BigDecimal minimumOrderPrice) {
         String name = "냥인의쿠폰";
-        BigDecimal discountAmount = BigDecimal.valueOf(2_500);
-        BigDecimal minimumOrderPrice = BigDecimal.valueOf(30_000);
         CouponCategory couponCategory = CouponCategory.FOOD;
         LocalDateTime issueStartedAt = LocalDateTime.of(2024, 10, 16, 0, 0, 0, 0);
         LocalDateTime issueEndedAt = LocalDateTime.of(2024, 10, 26, 23, 59, 59, 999_999_000);
         Coupon coupon = new Coupon(
                 name, discountAmount, minimumOrderPrice, couponCategory, issueStartedAt, issueEndedAt
         );
-        Coupon savedCoupon = couponService.createCoupon(coupon);
+        return couponService.createCoupon(coupon);
+    }
 
-        // when
-        AtomicReference<Exception> exceptionFromUser1 = new AtomicReference<>();
-        AtomicReference<Exception> exceptionFromUser2 = new AtomicReference<>();
+    private List<Exception> executeConcurrentUpdates(Runnable user1Task, Runnable user2Task)
+            throws InterruptedException {
+        List<Exception> exceptions = Collections.synchronizedList(new ArrayList<>());
+
         // 사용자 1: 쿠폰 할인 금액 변경 기능을 이용하여 할인 금액을 1,000원으로 수정
         Thread user1 = new Thread(() -> {
             try {
-                couponService.updateDiscountAmount(savedCoupon.getId(), BigDecimal.valueOf(1_000));
+                user1Task.run();
             } catch (Exception e) {
-                exceptionFromUser1.set(e);
+                exceptions.add(e);
             }
         });
         // 사용자 2: 쿠폰 최소 주문 금액 변경 기능을 이용하여 최소 주문 금액을 40,000원으로 수정
         Thread user2 = new Thread(() -> {
             try {
-                couponService.updateMinimumOrderPrice(savedCoupon.getId(), BigDecimal.valueOf(40_000));
+                user2Task.run();
             } catch (Exception e) {
-                exceptionFromUser2.set(e);
+                exceptions.add(e);
             }
         });
 
@@ -93,18 +105,6 @@ class CouponServiceTest {
         user1.join();
         user2.join();
 
-        // then
-        if (exceptionFromUser1.get() != null) {
-            assertThat(exceptionFromUser1.get()).isInstanceOf(ObjectOptimisticLockingFailureException.class);
-        }
-        if (exceptionFromUser2.get() != null) {
-            assertThat(exceptionFromUser2.get()).isInstanceOf(ObjectOptimisticLockingFailureException.class);
-        }
-        Coupon updatedCoupon = couponService.getCouponForce(savedCoupon.getId());
-        int discountRate = updatedCoupon.getDiscountAmount()
-                .multiply(BigDecimal.valueOf(100))
-                .divide(updatedCoupon.getMinimumOrderPrice(), 0, RoundingMode.DOWN)
-                .intValue();
-        assertThat(discountRate).isBetween(3, 20);
+        return exceptions;
     }
 }


### PR DESCRIPTION
안녕하세요 ^.^ 드디어 동시성 문제에 대해 다뤄보는군요. 꽤 어렵더라고요…
아마 코드가 많이 부족할 거예요. 여러분과 함께 차차 발전시켜나가고 싶어요. ㅎ ㅎ
잘 부탁드립니다. 😸

### 동시성 문제 해결 방법 및 근거
저는 **낙관적 락** 방식을 채택하여 쿠폰 정보 수정 기능의 동시성 문제를 해결하였습니다.
만약 충돌이 일어난 경우, 재시도 로직 없이 클라이언트에게 적절한 예외 메시지를 반환하는 방식으로 구현하였어요. 

이러한 방식을 선택한 이유는 다음과 같아요.

- **사용자 특성상 충돌 가능성이 낮다고 판단했습니다.**
    
    쿠폰 정보 수정 기능은 관리자만 사용하는 기능으로, 서로 다른 사용자가 동시에 쿠폰 정보를 수정하는 상황은 매우 드문 일이라 판단했습니다. 
    
    이러한 특성을 고려했을 때, 별도의 데이터 락 없이도 문제를 해결할 수 있으며, 성능과 구현 복잡도 측면에서 낙관적 락이 적합한 선택이라 생각했습니다.
    
- **문제 해결의 간단함과 사용성을 우선시하였습니다.**
    - 재시도 로직이 오히려 코드의 복잡도를 증가시키고 시스템 부하를 가중시킬 가능성이 있다고 판단하여, 충돌 발생 시 클라이언트에게 예외 메시지를 반환하는 간단한 방식으로 구현하였습니다.
    - 클라이언트가 예외 메시지를 통해 문제 상황을 명확히 이해하고, 필요한 경우 수동으로 재요청하도록 설계하는 것이 사용성 측면에서도 좋을 거라 판단하였습니다.
        - 관리자라는 사용자의 특성을 고려했을 때 최대한 선택지를 늘려주는 게 좋다고 생각했어요. 충돌이 발생한 경우 예외 메시지를 보고 재요청을 하거나 아니면 해당 데이터를 수정한 다른 관리자와 검토 과정을 갖거나 등등…
        

### 추가 참고사항
이번 미션에서는 ‘동시성 문제 해결’에만 초점을 맞췄습니다. 
앞서 진행했던 복제지연, 캐싱은 신경쓰지 못했어요. 
쿠폰 정보 수정 시 캐싱된 데이터에 대한 처리라든지, 복제지연을 유연하게 처리하는 부분은 제대로 안 되어 있을 가능성이 높아요.  😢

그래도 이 부분들에 대해 개선 의견을 주신다면 천천히라도 꼭 반영해 보겠습니다!